### PR TITLE
Security fix for Prototype Pollution

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -54,7 +54,7 @@ const utils = {
       return obj;
     }
     if (typeof path === 'string') {
-      const pathArray = path.split('.')
+      const pathArray = path.split('.');
       if (utils.isPrototypePolluted(pathArray[0]))
         return;
       return utils.set(obj, pathArray, value, doNotReplace);

--- a/utils.js
+++ b/utils.js
@@ -54,7 +54,10 @@ const utils = {
       return obj;
     }
     if (typeof path === 'string') {
-      return utils.set(obj, path.split('.'), value, doNotReplace);
+      const pathArray = path.split('.')
+      if (utils.isPrototypePolluted(pathArray[0]))
+        return;
+      return utils.set(obj, pathArray, value, doNotReplace);
     }
     const currentPath = path[0];
     const currentValue = obj[currentPath];
@@ -93,6 +96,9 @@ const utils = {
     } else {
       return Object.prototype.toString.call(value).slice(8, -1);
     }
+  },
+  isPrototypePolluted: function(key) {
+    return ['__proto__', 'constructor', 'prototype'].includes(key);
   }
 };
 


### PR DESCRIPTION
### :bar_chart: Metadata *

`merge-change` is vulnerable to `Prototype Pollution`.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-merge-change

### :gear: Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as `__proto__`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values. Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### :computer: Technical Description *

Fix implemented by not allowing to modify object prototype.

### :bug: Proof of Concept (PoC) *

1. Create the following PoC file:
```JavaScript
// poc.js
var mc = require("merge-change")

console.log("Before : " + {}.polluted);
const result = mc.merge({'__proto__':{}}, {$set:{'__proto__.polluted': 'Yes! Its Polluted'}});
console.log("After : " + {}.polluted);
```
2. Execute the following commands in terminal:
```bash
npm i merge-change # Install affected module
node poc.js #  Run the PoC
```
3. Check the Output:
```
Before : undefined
After : Yes! Its Polluted
```

### :fire: Proof of Fix (PoF) *

![image](https://user-images.githubusercontent.com/43996156/103802105-a9323380-5074-11eb-80cd-7076af20cc4c.png)

### +1 User Acceptance Testing (UAT)

* I've executed unit tests.
* After fix the functionality is unaffected.
